### PR TITLE
Made single list of stopwords, changed spacing and comments

### DIFF
--- a/scraper.py
+++ b/scraper.py
@@ -51,8 +51,9 @@ def is_valid(url):
         if parsed.scheme not in {"http", "https"}:
             return False
         if not re.match(r'(?:.+\.(?:i?cs|stat|informatics)\.uci\.edu$)', parsed.netloc):
+            # theoretically, shouldn't be here if path is in allowed domains
             return False
-        if not re.match(r'^/.*', parsed.path):
+        if not re.match(r'^/.*', parsed.path): # returns true if path is / followed by text
             return False
         if (is_trap(url)): #is_trap returns true if it is a trap
             return False
@@ -72,6 +73,7 @@ def is_valid(url):
         print("TypeError for ", parsed)
         raise
 
+
 def is_trap(url):
     known_traps = ["https://wics.ics.uci.edu/events", "ppsx"] #list of traps we found whilst running crawler
     for trap in known_traps:
@@ -79,12 +81,14 @@ def is_trap(url):
             return True
     return False
 
+
 def correct_domain(url):
     valid_domains = ["ics.uci.edu", "cs.uci.edu", "informatics.uci.edu", "stat.uci.edu"] #all valid domains
     for domain in valid_domains: #loops through each domain to see if the url contains it
         if domain in url:
             return True
     return False
+
 
 def is_high_quality_page(soup_content):
     bad_count = 100  # Minimum number of words for "low textual content" pages

--- a/tokenizer.py
+++ b/tokenizer.py
@@ -2,6 +2,7 @@ import re
 from collections import defaultdict
 from bs4 import BeautifulSoup
 
+
 def tokenize(soup_content):
     #gets all the text from the html page and gets rid of all punctuation except for ' and -
     html_text = re.sub(r'[^\w\'-]+', ' ', soup_content.get_text()) #got the regex formula using ChatGPT
@@ -11,29 +12,29 @@ def tokenize(soup_content):
     text_list = html_text.split() #puts all the words into a list
     return text_list
 
+
 def compute_word_frequencies(token_list):
-    stopwords = {'a', 'about', 'above', 'after', 'again', 'against', 'all', 'am', 'an', 'and', 'any', 'are', 'as',
-                      'at', 'be', 'because', 'been', 'before', 'being', 'below', 'between', 'both', 'but', 'by',
-                      'cannot', 'could', 'did', 'do', 'does', 'doing', 'down', 'during', 'each', 'few', 'for', 'from',
-                      'further', 'had', 'has', 'have', 'having', 'he', 'her', 'here', 'hers', 'herself', 'him',
-                      'himself', 'his', 'how', 'i', 'if', 'in', 'into', 'is', 'it', 'its', 'itself', 'me', 'more',
-                      'most', 'my', 'myself', 'no', 'nor', 'not', 'of', 'off', 'on', 'once', 'only', 'or', 'other',
-                      'ought', 'our', 'ours', 'ourselves', 'out', 'over', 'own', 'same', 'she', 'should', 'so', 'some',
-                      'such', 'than', 'that', 'the', 'their', 'theirs', 'them', 'themselves', 'then', 'there', 'these',
-                      'they', 'this', 'those', 'through', 'to', 'too', 'under', 'until', 'up', 'very', 'was', 'we',
-                      'were', 'what', 'when', 'where', 'which', 'while', 'who', 'whom', 'why', 'with', 'would', 'you',
-                      'your', 'yours', 'yourself', 'yourselves'}
-    apostrophe_stopwords = {"aren't", "can't", "couldn't", "didn't", "doesn't", "don't", "hadn't", "hasn't",
-                                 "haven't", "he'd", "he'll", "he's", "here's", "how's", "i'd", "i'll", "i'm", "i've",
-                                 "isn't", "it's", "let's", "mustn't", "shan't", "she'd", "she'll", "she's", "shouldn't",
-                                 "that's", "there's", "they'd", "they'll", "they're", "they've", "wasn't", "we'd",
-                                 "we'll", "we're", "we've", "weren't", "what's", "when's", "where's", "who's", "why's",
-                                 "won't", "wouldn't", "you'd", "you'll", "you're", "you've"}
+    stopwords = {'a', 'about', 'above', 'after', 'again', 'against', 'all', 'am', 'an', 'and', 'any', 'are', "aren't",
+                 'as', 'at', 'be', 'because', 'been', 'before', 'being', 'below', 'between', 'both', 'but', 'by',
+                 "can't", 'cannot', 'could', "couldn't", 'did', "didn't", 'do', 'does', "doesn't", 'doing', "don't",
+                 'down', 'during', 'each', 'few', 'for', 'from', 'further', 'had', "hadn't", 'has', "hasn't", 'have',
+                 "haven't", 'having', 'he', "he'd", "he'll", "he's", 'her', 'here', "here's", 'hers', 'herself', 'him',
+                 'himself', 'his', 'how', "how's", 'i', "i'd", "i'll", "i'm", "i've", 'if', 'in', 'into', 'is', "isn't",
+                 'it', "it's", 'its', 'itself', "let's", 'me', 'more', 'most', "mustn't", 'my', 'myself', 'no', 'nor',
+                 'not', 'of', 'off', 'on', 'once', 'only', 'or', 'other', 'ought', 'our', 'ours', 'ourselves', 'out',
+                 'over', 'own', 'same', "shan't", 'she', "she'd", "she'll", "she's", 'should', "shouldn't", 'so',
+                 'some', 'such', 'than', 'that', "that's", 'the', 'their', 'theirs', 'them', 'themselves', 'then',
+                 'there', "there's", 'these', 'they', "they'd", "they'll", "they're", "they've", 'this', 'those',
+                 'through', 'to', 'too', 'under', 'until', 'up', 'very', 'was', "wasn't", 'we', "we'd", "we'll",
+                 "we're", "we've", 'were', "weren't", 'what', "what's", 'when', "when's", 'where', "where's", 'which',
+                 'while', 'who', "who's", 'whom', 'why', "why's", 'with', "won't", 'would', "wouldn't", 'you', "you'd",
+                 "you'll", "you're", "you've", 'your', 'yours', 'yourself', 'yourselves'}
     frequencies = defaultdict(int)
     for token in token_list:
-        if (token not in stopwords and token not in apostrophe_stopwords):
+        if (token not in stopwords):
             frequencies[token] += 1
     return frequencies
+
 
 def token_print(frequencies):
     double_sorted = sorted(sorted(frequencies.items(), key=(lambda x: x[0])), key=(lambda x: x[1]), reverse=True)
@@ -42,4 +43,4 @@ def token_print(frequencies):
 
 
 if __name__ == '__main__':
-    token_print(compute_word_frequencies(tokenize('README.md', True)))
+    token_print(compute_word_frequencies(tokenize('<p>This is a test</p>')))


### PR DESCRIPTION
The apostrophe_stopwords and stopwords could be turned into a single list. I also indented some things and explained things that I should have made more clear.